### PR TITLE
Fix exploitable buffer overflow

### DIFF
--- a/src/xorg/ts_xorg_client.c
+++ b/src/xorg/ts_xorg_client.c
@@ -539,7 +539,7 @@ ts_xorg_client_create(
 	res->mux = mux;
 
 	char name[128];
-	strcpy(name, param);
+	strncpy(name, param, 127);
 	char * where = strchr(name, '=');
 	if (where) {
 		*where = 0;


### PR DESCRIPTION
This buffer overflow can be exploited by specifying the -x launch parameter with a value larger than 312 bytes, as this will overwrite the return address on the stack, thus allowing arbitrary code execution.